### PR TITLE
014: Fix Round Timeline Data

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -425,6 +425,7 @@ func (s *parseState) onRoundEnd(e events.RoundEnd) {
 		Clutch:     clutch,
 		CTEconomy:  s.ctEconomy,
 		TEconomy:   s.tEconomy,
+		StartTime:  s.roundStart,
 		Duration:   duration,
 		BombPlant:  s.roundBomb,
 		BombDefuse: s.roundDefuse,

--- a/parser/types.go
+++ b/parser/types.go
@@ -80,6 +80,7 @@ type Round struct {
 	Clutch     *ClutchInfo
 	CTEconomy  EconomySnapshot
 	TEconomy   EconomySnapshot
+	StartTime  time.Duration // game time at freeze-time end
 	Duration   time.Duration
 	BombPlant  *BombEvent
 	BombDefuse *BombEvent

--- a/repository/migrations/002_round_first_kill_details.sql
+++ b/repository/migrations/002_round_first_kill_details.sql
@@ -1,0 +1,9 @@
+ALTER TABLE rounds ADD COLUMN first_kill_steam_id TEXT;
+ALTER TABLE rounds ADD COLUMN first_death_steam_id TEXT;
+ALTER TABLE rounds ADD COLUMN first_kill_weapon TEXT;
+ALTER TABLE rounds ADD COLUMN first_kill_round_time REAL;
+ALTER TABLE rounds ADD COLUMN bomb_plant_steam_id TEXT;
+ALTER TABLE rounds ADD COLUMN bomb_plant_site TEXT;
+ALTER TABLE rounds ADD COLUMN bomb_plant_round_time REAL;
+ALTER TABLE rounds ADD COLUMN bomb_defuse_steam_id TEXT;
+ALTER TABLE rounds ADD COLUMN bomb_defuse_round_time REAL;

--- a/repository/sqlite_test.go
+++ b/repository/sqlite_test.go
@@ -48,10 +48,16 @@ func seedMatch(t *testing.T, repo *SQLite) Match {
 			{
 				ID: "r1", Number: 1, WinnerTeam: "CT", WinMethod: "Elimination",
 				FirstKillPlayerID: "p1", FirstDeathPlayerID: "p2",
+				FirstKillSteamID: "76561198001", FirstDeathSteamID: "76561198002",
+				FirstKillWeapon: "AK-47", FirstKillRoundTime: 5.3,
 			},
 			{
 				ID: "r2", Number: 2, WinnerTeam: "T", WinMethod: "BombExploded",
 				FirstKillPlayerID: "p2", FirstDeathPlayerID: "p1",
+				FirstKillSteamID: "76561198002", FirstDeathSteamID: "76561198001",
+				FirstKillWeapon: "AWP", FirstKillRoundTime: 12.7,
+				BombPlantSteamID: "76561198002", BombPlantSite: "B",
+				BombPlantRoundTime: 35.2,
 				Clutch: &Clutch{
 					RoundID: "r2", PlayerID: "p2", Opponents: 2, Success: true,
 				},
@@ -292,6 +298,18 @@ func TestGetRounds(t *testing.T) {
 	if r1.Clutch != nil {
 		t.Error("round 1 should have no clutch")
 	}
+	if r1.FirstKillSteamID != "76561198001" {
+		t.Errorf("round 1 first kill steam ID: got %s, want 76561198001", r1.FirstKillSteamID)
+	}
+	if r1.FirstDeathSteamID != "76561198002" {
+		t.Errorf("round 1 first death steam ID: got %s, want 76561198002", r1.FirstDeathSteamID)
+	}
+	if r1.FirstKillWeapon != "AK-47" {
+		t.Errorf("round 1 first kill weapon: got %s, want AK-47", r1.FirstKillWeapon)
+	}
+	if r1.FirstKillRoundTime != 5.3 {
+		t.Errorf("round 1 first kill round time: got %f, want 5.3", r1.FirstKillRoundTime)
+	}
 
 	r2 := rounds[1]
 	if r2.Clutch == nil {
@@ -302,6 +320,18 @@ func TestGetRounds(t *testing.T) {
 	}
 	if r2.Clutch.Opponents != 2 {
 		t.Errorf("clutch opponents: got %d, want 2", r2.Clutch.Opponents)
+	}
+	if r2.BombPlantSteamID != "76561198002" {
+		t.Errorf("round 2 bomb plant steam ID: got %s, want 76561198002", r2.BombPlantSteamID)
+	}
+	if r2.BombPlantSite != "B" {
+		t.Errorf("round 2 bomb plant site: got %s, want B", r2.BombPlantSite)
+	}
+	if r2.BombPlantRoundTime != 35.2 {
+		t.Errorf("round 2 bomb plant round time: got %f, want 35.2", r2.BombPlantRoundTime)
+	}
+	if r2.BombDefuseSteamID != "" {
+		t.Errorf("round 2 should have no defuse, got steam ID %s", r2.BombDefuseSteamID)
 	}
 }
 

--- a/repository/types.go
+++ b/repository/types.go
@@ -78,6 +78,15 @@ type Round struct {
 	WinMethod          string
 	FirstKillPlayerID  string
 	FirstDeathPlayerID string
+	FirstKillSteamID   string
+	FirstDeathSteamID  string
+	FirstKillWeapon    string
+	FirstKillRoundTime float64
+	BombPlantSteamID   string
+	BombPlantSite      string
+	BombPlantRoundTime float64
+	BombDefuseSteamID  string
+	BombDefuseRoundTime float64
 	Clutch             *Clutch
 }
 

--- a/service/mapping.go
+++ b/service/mapping.go
@@ -58,19 +58,39 @@ func mapParsedMatch(pm *parser.Match, demoHash string) repository.Match {
 
 		firstKillPID := ""
 		firstDeathPID := ""
+		firstKillSteamID := ""
+		firstDeathSteamID := ""
+		firstKillWeapon := ""
+		var firstKillRoundTime float64
 		if r.FirstKill != nil {
 			firstKillPID = playerIDs[steamIDStr(r.FirstKill.AttackerSteamID)]
 			firstDeathPID = playerIDs[steamIDStr(r.FirstKill.VictimSteamID)]
+			firstKillSteamID = steamIDStr(r.FirstKill.AttackerSteamID)
+			firstDeathSteamID = steamIDStr(r.FirstKill.VictimSteamID)
+			firstKillWeapon = r.FirstKill.Weapon
+			firstKillRoundTime = (r.FirstKill.Time - r.StartTime).Seconds()
 		}
 
 		round := repository.Round{
-			ID:                 roundID,
-			MatchID:            matchID,
-			Number:             r.Number,
-			WinnerTeam:         r.Winner.String(),
-			WinMethod:          r.WinMethod.String(),
-			FirstKillPlayerID:  firstKillPID,
-			FirstDeathPlayerID: firstDeathPID,
+			ID:                  roundID,
+			MatchID:             matchID,
+			Number:              r.Number,
+			WinnerTeam:          r.Winner.String(),
+			WinMethod:           r.WinMethod.String(),
+			FirstKillPlayerID:   firstKillPID,
+			FirstDeathPlayerID:  firstDeathPID,
+			FirstKillSteamID:    firstKillSteamID,
+			FirstDeathSteamID:   firstDeathSteamID,
+			FirstKillWeapon:     firstKillWeapon,
+			FirstKillRoundTime:  firstKillRoundTime,
+		}
+
+		if r.BombPlant != nil {
+			round.BombPlantSteamID = steamIDStr(r.BombPlant.PlayerSteamID)
+			round.BombPlantSite = r.BombPlant.Site
+		}
+		if r.BombDefuse != nil {
+			round.BombDefuseSteamID = steamIDStr(r.BombDefuse.PlayerSteamID)
 		}
 
 		if r.Clutch != nil {
@@ -214,6 +234,23 @@ func mapRepoRounds(rs []repository.Round) []RoundEvent {
 			WinMethod:          r.WinMethod,
 			FirstKillPlayerID:  r.FirstKillPlayerID,
 			FirstDeathPlayerID: r.FirstDeathPlayerID,
+			FirstKillSteamID:   r.FirstKillSteamID,
+			FirstDeathSteamID:  r.FirstDeathSteamID,
+			FirstKillWeapon:    r.FirstKillWeapon,
+			FirstKillRoundTime: r.FirstKillRoundTime,
+		}
+		if r.BombPlantSteamID != "" {
+			out[i].Plant = &PlantEvent{
+				PlanterSteamID: r.BombPlantSteamID,
+				Site:           r.BombPlantSite,
+				RoundTime:      r.BombPlantRoundTime,
+			}
+		}
+		if r.BombDefuseSteamID != "" {
+			out[i].Defuse = &DefuseEvent{
+				DefuserSteamID: r.BombDefuseSteamID,
+				RoundTime:      r.BombDefuseRoundTime,
+			}
 		}
 		if r.Clutch != nil {
 			out[i].Clutch = &ClutchEvent{

--- a/service/types.go
+++ b/service/types.go
@@ -64,7 +64,26 @@ type RoundEvent struct {
 	WinMethod          string
 	FirstKillPlayerID  string
 	FirstDeathPlayerID string
+	FirstKillSteamID   string
+	FirstDeathSteamID  string
+	FirstKillWeapon    string
+	FirstKillRoundTime float64
+	Plant              *PlantEvent
+	Defuse             *DefuseEvent
 	Clutch             *ClutchEvent
+}
+
+// PlantEvent describes a bomb plant in a round.
+type PlantEvent struct {
+	PlanterSteamID string
+	Site           string
+	RoundTime      float64
+}
+
+// DefuseEvent describes a bomb defuse in a round.
+type DefuseEvent struct {
+	DefuserSteamID string
+	RoundTime      float64
 }
 
 // ClutchEvent describes a clutch attempt.

--- a/transport/grpc/mapping.go
+++ b/transport/grpc/mapping.go
@@ -162,12 +162,25 @@ func roundEventToProto(r service.RoundEvent) *statsv1.RoundEvent {
 		Winner:      r.WinnerTeam,
 		WinMethod:   parseWinMethod(r.WinMethod),
 	}
-	// first kill: we only have player IDs from the service, not steam IDs.
-	// map them as-is since they're the identifiers the service layer provides.
-	if r.FirstKillPlayerID != "" || r.FirstDeathPlayerID != "" {
+	if r.FirstKillSteamID != "" || r.FirstDeathSteamID != "" {
 		pe.FirstKill = &statsv1.FirstKill{
-			AttackerSteamId: r.FirstKillPlayerID,
-			VictimSteamId:   r.FirstDeathPlayerID,
+			AttackerSteamId: r.FirstKillSteamID,
+			VictimSteamId:   r.FirstDeathSteamID,
+			Weapon:          r.FirstKillWeapon,
+			RoundTime:       float32(r.FirstKillRoundTime),
+		}
+	}
+	if r.Plant != nil {
+		pe.Plant = &statsv1.PlantEvent{
+			PlanterSteamId: r.Plant.PlanterSteamID,
+			Site:           r.Plant.Site,
+			RoundTime:      float32(r.Plant.RoundTime),
+		}
+	}
+	if r.Defuse != nil {
+		pe.Defuse = &statsv1.DefuseEvent{
+			DefuserSteamId: r.Defuse.DefuserSteamID,
+			RoundTime:      float32(r.Defuse.RoundTime),
 		}
 	}
 	if r.Clutch != nil {


### PR DESCRIPTION
Closes #15

Spec: .manager/specs/014-cs2stats-round-timeline-fixes.md

- Store first kill Steam IDs alongside internal UUIDs so the API returns real Steam IDs
- Carry weapon and round time through parser → repo → service → transport
- Add bomb plant/defuse data to round timeline response
- Schema migration 002 adds 9 new columns to `rounds` table
- Version-tracked migration system for safe ALTER TABLE