### PR TITLE
013: Match Views UX Overhaul

### DIFF
--- a/frontend/src/components/EconomyChart.tsx
+++ b/frontend/src/components/EconomyChart.tsx
@@ -1,7 +1,7 @@
 import {
   ResponsiveContainer,
   ComposedChart,
-  Line,
+  Area,
   Bar,
   XAxis,
   YAxis,
@@ -10,6 +10,16 @@ import {
   Legend,
 } from "recharts";
 import type { EconomyRound, BuyType } from "../api/types";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
 
 interface EconomyChartProps {
   rounds: EconomyRound[];
@@ -32,16 +42,16 @@ function buyTypeLabel(bt: BuyType): string {
   }
 }
 
-function buyTypeBadgeColor(bt: BuyType): string {
+function buyTypeBadgeClass(bt: BuyType): string {
   switch (bt) {
     case "BUY_TYPE_ECO":
-      return "bg-red-800 text-red-200";
+      return "bg-red-500/20 text-red-400 border-red-500/30";
     case "BUY_TYPE_FORCE":
-      return "bg-yellow-800 text-yellow-200";
+      return "bg-yellow-500/20 text-yellow-400 border-yellow-500/30";
     case "BUY_TYPE_FULL":
-      return "bg-green-800 text-green-200";
+      return "bg-green-500/20 text-green-400 border-green-500/30";
     case "BUY_TYPE_PISTOL":
-      return "bg-purple-800 text-purple-200";
+      return "bg-purple-500/20 text-purple-400 border-purple-500/30";
     default:
       return "bg-muted text-muted-foreground";
   }
@@ -66,118 +76,153 @@ export function EconomyChart({
   }));
 
   return (
-    <div>
+    <div className="space-y-4">
       {/* chart */}
-      <div className="h-80">
-        <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 20 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="hsl(215 20% 22%)" />
-            <XAxis
-              dataKey="round"
-              tick={{ fill: "hsl(215 15% 60%)", fontSize: 12 }}
-              label={{ value: "Round", fill: "hsl(215 15% 60%)", position: "insideBottom", offset: -5 }}
-            />
-            <YAxis
-              tick={{ fill: "hsl(215 15% 60%)", fontSize: 12 }}
-              label={{
-                value: "Equipment Value ($)",
-                fill: "hsl(215 15% 60%)",
-                angle: -90,
-                position: "insideLeft",
-              }}
-            />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: "hsl(215 25% 12%)",
-                border: "1px solid hsl(215 20% 22%)",
-                borderRadius: "8px",
-              }}
-              labelStyle={{ color: "hsl(215 15% 90%)" }}
-            />
-            <Legend wrapperStyle={{ color: "hsl(215 15% 60%)" }} />
-            <Bar
-              dataKey="teamASpend"
-              name={`${teamAName} Spend`}
-              fill={CT_COLOR}
-              opacity={0.3}
-              barSize={8}
-            />
-            <Bar
-              dataKey="teamBSpend"
-              name={`${teamBName} Spend`}
-              fill={T_COLOR}
-              opacity={0.3}
-              barSize={8}
-            />
-            <Line
-              type="monotone"
-              dataKey="teamAEquip"
-              name={`${teamAName} Equip`}
-              stroke={CT_COLOR}
-              strokeWidth={2}
-              dot={false}
-            />
-            <Line
-              type="monotone"
-              dataKey="teamBEquip"
-              name={`${teamBName} Equip`}
-              stroke={T_COLOR}
-              strokeWidth={2}
-              dot={false}
-            />
-          </ComposedChart>
-        </ResponsiveContainer>
-      </div>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Equipment Value</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <ComposedChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 20 }}>
+                <defs>
+                  <linearGradient id="ctGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor={CT_COLOR} stopOpacity={0.3} />
+                    <stop offset="95%" stopColor={CT_COLOR} stopOpacity={0.05} />
+                  </linearGradient>
+                  <linearGradient id="tGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor={T_COLOR} stopOpacity={0.3} />
+                    <stop offset="95%" stopColor={T_COLOR} stopOpacity={0.05} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(215 20% 18%)" />
+                <XAxis
+                  dataKey="round"
+                  tick={{ fill: "hsl(215 15% 50%)", fontSize: 11 }}
+                  label={{
+                    value: "Round",
+                    fill: "hsl(215 15% 50%)",
+                    position: "insideBottom",
+                    offset: -5,
+                    fontSize: 11,
+                  }}
+                />
+                <YAxis
+                  tick={{ fill: "hsl(215 15% 50%)", fontSize: 11 }}
+                  label={{
+                    value: "Value ($)",
+                    fill: "hsl(215 15% 50%)",
+                    angle: -90,
+                    position: "insideLeft",
+                    fontSize: 11,
+                  }}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "hsl(215 25% 12%)",
+                    border: "1px solid hsl(215 20% 22%)",
+                    borderRadius: "8px",
+                    fontSize: 12,
+                  }}
+                  labelStyle={{ color: "hsl(215 15% 80%)" }}
+                />
+                <Legend
+                  wrapperStyle={{ color: "hsl(215 15% 60%)", fontSize: 12 }}
+                />
+                <Bar
+                  dataKey="teamASpend"
+                  name={`${teamAName} Spend`}
+                  fill={CT_COLOR}
+                  opacity={0.25}
+                  barSize={6}
+                />
+                <Bar
+                  dataKey="teamBSpend"
+                  name={`${teamBName} Spend`}
+                  fill={T_COLOR}
+                  opacity={0.25}
+                  barSize={6}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="teamAEquip"
+                  name={`${teamAName} Equip`}
+                  stroke={CT_COLOR}
+                  strokeWidth={2}
+                  fill="url(#ctGradient)"
+                  dot={false}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="teamBEquip"
+                  name={`${teamBName} Equip`}
+                  stroke={T_COLOR}
+                  strokeWidth={2}
+                  fill="url(#tGradient)"
+                  dot={false}
+                />
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
+        </CardContent>
+      </Card>
 
-      {/* buy type badges per round */}
-      <div className="mt-6">
-        <h4 className="mb-2 text-sm font-medium text-muted-foreground">
-          Buy Types
-        </h4>
-        <div className="overflow-x-auto">
-          <table className="text-xs">
-            <thead>
-              <tr>
-                <th className="px-2 py-1 text-left text-muted-foreground/70">Team</th>
+      {/* buy type table */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Buy Types</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto p-0 pb-2">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="sticky left-0 bg-card pl-4">Team</TableHead>
                 {rounds.map((r) => (
-                  <th
+                  <TableHead
                     key={r.roundNumber}
-                    className="px-1 py-1 text-center text-muted-foreground/70"
+                    className="text-center text-xs"
                   >
                     R{r.roundNumber}
-                  </th>
+                  </TableHead>
                 ))}
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td className="px-2 py-1 text-team-ct">{teamAName}</td>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell className="sticky left-0 bg-card pl-4 text-team-ct">
+                  {teamAName}
+                </TableCell>
                 {rounds.map((r) => (
-                  <td key={r.roundNumber} className="px-1 py-1 text-center">
-                    <span
-                      className={`inline-block rounded px-1 py-0.5 text-[10px] ${buyTypeBadgeColor(r.teamABuyType)}`}
+                  <TableCell key={r.roundNumber} className="text-center">
+                    <Badge
+                      variant="outline"
+                      className={`px-1.5 py-0 text-[10px] ${buyTypeBadgeClass(r.teamABuyType)}`}
                     >
                       {buyTypeLabel(r.teamABuyType)}
-                    </span>
-                  </td>
+                    </Badge>
+                  </TableCell>
                 ))}
-              </tr>
-              <tr>
-                <td className="px-2 py-1 text-team-t">{teamBName}</td>
+              </TableRow>
+              <TableRow>
+                <TableCell className="sticky left-0 bg-card pl-4 text-team-t">
+                  {teamBName}
+                </TableCell>
                 {rounds.map((r) => (
-                  <td key={r.roundNumber} className="px-1 py-1 text-center">
-                    <span
-                      className={`inline-block rounded px-1 py-0.5 text-[10px] ${buyTypeBadgeColor(r.teamBBuyType)}`}
+                  <TableCell key={r.roundNumber} className="text-center">
+                    <Badge
+                      variant="outline"
+                      className={`px-1.5 py-0 text-[10px] ${buyTypeBadgeClass(r.teamBBuyType)}`}
                     >
                       {buyTypeLabel(r.teamBBuyType)}
-                    </span>
-                  </td>
+                    </Badge>
+                  </TableCell>
                 ))}
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/components/KillMap.tsx
+++ b/frontend/src/components/KillMap.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from "react";
 import type { KillPosition, Player } from "../api/types";
 import { Select } from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface KillMapProps {
   kills: KillPosition[];
@@ -37,7 +38,6 @@ export function KillMap({
     [kills],
   );
 
-  // compute coordinate bounds for normalization
   const bounds = useMemo(() => {
     if (kills.length === 0) return { minX: 0, maxX: 1, minY: 0, maxY: 1 };
     let minX = Infinity,
@@ -52,7 +52,6 @@ export function KillMap({
         if (pos.y > maxY) maxY = pos.y;
       }
     }
-    // add padding
     const padX = (maxX - minX) * 0.05 || 1;
     const padY = (maxY - minY) * 0.05 || 1;
     return { minX: minX - padX, maxX: maxX + padX, minY: minY - padY, maxY: maxY + padY };
@@ -82,194 +81,222 @@ export function KillMap({
   const teamColor = (steamId: string) =>
     playerTeam.get(steamId) === "CT" ? CT_COLOR : T_COLOR;
 
-  const playerName = (steamId: string) =>
+  const getPlayerName = (steamId: string) =>
     players.find((p) => p.steamId === steamId)?.name ?? steamId;
 
   const roundOptions = Array.from({ length: totalRounds }, (_, i) => i + 1);
 
   return (
-    <div>
-      {/* filters */}
-      <div className="mb-4 flex flex-wrap gap-3">
-        <Select
-          value={filterRound}
-          onChange={(e) => setFilterRound(Number(e.target.value))}
-          className="w-auto"
-        >
-          <option value={0}>All Rounds</option>
-          {roundOptions.map((r) => (
-            <option key={r} value={r}>
-              Round {r}
-            </option>
-          ))}
-        </Select>
+    <div className="space-y-4">
+      {/* filter bar */}
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex flex-wrap gap-3">
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Round</label>
+              <Select
+                value={filterRound}
+                onChange={(e) => setFilterRound(Number(e.target.value))}
+                className="w-[140px]"
+              >
+                <option value={0}>All Rounds</option>
+                {roundOptions.map((r) => (
+                  <option key={r} value={r}>
+                    Round {r}
+                  </option>
+                ))}
+              </Select>
+            </div>
 
-        <Select
-          value={filterPlayer}
-          onChange={(e) => setFilterPlayer(e.target.value)}
-          className="w-auto"
-        >
-          <option value="">All Players</option>
-          {players.map((p) => (
-            <option key={p.steamId} value={p.steamId}>
-              {p.name}
-            </option>
-          ))}
-        </Select>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Player</label>
+              <Select
+                value={filterPlayer}
+                onChange={(e) => setFilterPlayer(e.target.value)}
+                className="w-[160px]"
+              >
+                <option value="">All Players</option>
+                {players.map((p) => (
+                  <option key={p.steamId} value={p.steamId}>
+                    {p.name}
+                  </option>
+                ))}
+              </Select>
+            </div>
 
-        <Select
-          value={filterWeapon}
-          onChange={(e) => setFilterWeapon(e.target.value)}
-          className="w-auto"
-        >
-          <option value="">All Weapons</option>
-          {weapons.map((w) => (
-            <option key={w} value={w}>
-              {w}
-            </option>
-          ))}
-        </Select>
-      </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Weapon</label>
+              <Select
+                value={filterWeapon}
+                onChange={(e) => setFilterWeapon(e.target.value)}
+                className="w-[160px]"
+              >
+                <option value="">All Weapons</option>
+                {weapons.map((w) => (
+                  <option key={w} value={w}>
+                    {w}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* map canvas */}
-      <div className="relative inline-block rounded-lg bg-muted p-2">
-        <svg
-          width={MAP_SIZE}
-          height={MAP_SIZE}
-          className="rounded bg-background"
-        >
-          {/* grid lines */}
-          {Array.from({ length: 11 }, (_, i) => {
-            const pos = (i / 10) * MAP_SIZE;
-            return (
-              <g key={i}>
-                <line
-                  x1={pos}
-                  y1={0}
-                  x2={pos}
-                  y2={MAP_SIZE}
-                  stroke="hsl(215 25% 15%)"
-                  strokeWidth={1}
-                />
-                <line
-                  x1={0}
-                  y1={pos}
-                  x2={MAP_SIZE}
-                  y2={pos}
-                  stroke="hsl(215 25% 15%)"
-                  strokeWidth={1}
-                />
-              </g>
-            );
-          })}
-
-          {/* kill lines and dots */}
-          {filtered.map((k, i) => {
-            const ap = normalize(k.attackerPos.x, k.attackerPos.y);
-            const vp = normalize(k.victimPos.x, k.victimPos.y);
-            return (
-              <g key={i}>
-                {/* line from attacker to victim */}
-                <line
-                  x1={ap.nx}
-                  y1={ap.ny}
-                  x2={vp.nx}
-                  y2={vp.ny}
-                  stroke="hsl(215 15% 35%)"
-                  strokeWidth={0.5}
-                  opacity={0.4}
-                />
-                {/* attacker dot */}
-                <circle
-                  cx={ap.nx}
-                  cy={ap.ny}
-                  r={k.isHeadshot ? 5 : 4}
-                  fill={teamColor(k.attackerSteamId)}
-                  opacity={0.8}
-                  stroke={k.isHeadshot ? "#fff" : "none"}
-                  strokeWidth={k.isHeadshot ? 1 : 0}
-                  onMouseEnter={() =>
-                    setHovered({ kill: k, x: ap.nx, y: ap.ny })
-                  }
-                  onMouseLeave={() => setHovered(null)}
-                  className="cursor-pointer"
-                />
-                {/* victim dot (X mark) */}
-                <g
-                  onMouseEnter={() =>
-                    setHovered({ kill: k, x: vp.nx, y: vp.ny })
-                  }
-                  onMouseLeave={() => setHovered(null)}
-                  className="cursor-pointer"
-                >
+      <div className="flex flex-col items-start gap-4 lg:flex-row">
+        <div className="relative inline-block rounded-lg border border-border bg-card p-3">
+          <svg
+            width={MAP_SIZE}
+            height={MAP_SIZE}
+            className="rounded bg-background"
+            style={{ maxWidth: "100%", height: "auto" }}
+          >
+            {/* grid */}
+            {Array.from({ length: 11 }, (_, i) => {
+              const pos = (i / 10) * MAP_SIZE;
+              return (
+                <g key={i}>
                   <line
-                    x1={vp.nx - 3}
-                    y1={vp.ny - 3}
-                    x2={vp.nx + 3}
-                    y2={vp.ny + 3}
-                    stroke={teamColor(k.victimSteamId)}
-                    strokeWidth={2}
-                    opacity={0.7}
+                    x1={pos} y1={0} x2={pos} y2={MAP_SIZE}
+                    stroke="hsl(215 25% 13%)" strokeWidth={1}
                   />
                   <line
-                    x1={vp.nx + 3}
-                    y1={vp.ny - 3}
-                    x2={vp.nx - 3}
-                    y2={vp.ny + 3}
-                    stroke={teamColor(k.victimSteamId)}
-                    strokeWidth={2}
-                    opacity={0.7}
+                    x1={0} y1={pos} x2={MAP_SIZE} y2={pos}
+                    stroke="hsl(215 25% 13%)" strokeWidth={1}
                   />
                 </g>
-              </g>
-            );
-          })}
-        </svg>
+              );
+            })}
 
-        {/* hover tooltip */}
-        {hovered && (
-          <div
-            className="pointer-events-none absolute z-10 rounded bg-card border border-border px-3 py-2 text-xs shadow-lg"
-            style={{
-              left: hovered.x + 12,
-              top: hovered.y - 10,
-            }}
-          >
-            <div className="text-foreground">
-              {playerName(hovered.kill.attackerSteamId)}{" "}
-              <span className="text-muted-foreground">&rarr;</span>{" "}
-              {playerName(hovered.kill.victimSteamId)}
-            </div>
-            <div className="text-muted-foreground">
-              {hovered.kill.weapon}
-              {hovered.kill.isHeadshot && " (HS)"}
-            </div>
-            <div className="text-muted-foreground/70">Round {hovered.kill.roundNumber}</div>
-          </div>
-        )}
+            {/* glow filter */}
+            <defs>
+              <filter id="glow">
+                <feGaussianBlur stdDeviation="2" result="blur" />
+                <feMerge>
+                  <feMergeNode in="blur" />
+                  <feMergeNode in="SourceGraphic" />
+                </feMerge>
+              </filter>
+            </defs>
 
-        {/* legend */}
-        <div className="mt-2 flex items-center gap-4 text-xs text-muted-foreground">
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2 w-2 rounded-full bg-team-ct" />
-            <span>{teamAName} (attacker)</span>
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2 w-2 rounded-full bg-team-t" />
-            <span>{teamBName} (attacker)</span>
-          </span>
-          <span className="flex items-center gap-1">
-            <svg width="10" height="10">
-              <line x1="1" y1="1" x2="9" y2="9" stroke="currentColor" strokeWidth="2" />
-              <line x1="9" y1="1" x2="1" y2="9" stroke="currentColor" strokeWidth="2" />
-            </svg>
-            <span>victim</span>
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2.5 w-2.5 rounded-full border border-white bg-muted" />
-            <span>headshot</span>
-          </span>
+            {/* kill lines and markers */}
+            {filtered.map((k, i) => {
+              const ap = normalize(k.attackerPos.x, k.attackerPos.y);
+              const vp = normalize(k.victimPos.x, k.victimPos.y);
+              const aColor = teamColor(k.attackerSteamId);
+              const vColor = teamColor(k.victimSteamId);
+              return (
+                <g key={i}>
+                  {/* dotted line */}
+                  <line
+                    x1={ap.nx} y1={ap.ny} x2={vp.nx} y2={vp.ny}
+                    stroke="hsl(215 15% 30%)"
+                    strokeWidth={0.8}
+                    strokeDasharray="3 3"
+                    opacity={0.4}
+                  />
+                  {/* attacker dot with glow */}
+                  <circle
+                    cx={ap.nx} cy={ap.ny}
+                    r={k.isHeadshot ? 5 : 4}
+                    fill={aColor}
+                    opacity={0.9}
+                    filter="url(#glow)"
+                    stroke={k.isHeadshot ? "#fff" : aColor}
+                    strokeWidth={k.isHeadshot ? 1.5 : 0.5}
+                    strokeOpacity={k.isHeadshot ? 0.8 : 0.3}
+                    onMouseEnter={() => setHovered({ kill: k, x: ap.nx, y: ap.ny })}
+                    onMouseLeave={() => setHovered(null)}
+                    className="cursor-pointer"
+                  />
+                  {/* victim X mark */}
+                  <g
+                    onMouseEnter={() => setHovered({ kill: k, x: vp.nx, y: vp.ny })}
+                    onMouseLeave={() => setHovered(null)}
+                    className="cursor-pointer"
+                  >
+                    <line
+                      x1={vp.nx - 4} y1={vp.ny - 4} x2={vp.nx + 4} y2={vp.ny + 4}
+                      stroke={vColor} strokeWidth={2} opacity={0.8}
+                    />
+                    <line
+                      x1={vp.nx + 4} y1={vp.ny - 4} x2={vp.nx - 4} y2={vp.ny + 4}
+                      stroke={vColor} strokeWidth={2} opacity={0.8}
+                    />
+                  </g>
+                </g>
+              );
+            })}
+          </svg>
+
+          {/* hover tooltip */}
+          {hovered && (
+            <div
+              className="pointer-events-none absolute z-10 rounded-lg border border-border bg-card px-3 py-2 text-xs shadow-lg"
+              style={{
+                left: Math.min(hovered.x + 16, MAP_SIZE - 120),
+                top: Math.max(hovered.y - 10, 0),
+              }}
+            >
+              <div className="font-medium text-foreground">
+                {getPlayerName(hovered.kill.attackerSteamId)}{" "}
+                <span className="text-muted-foreground">&rarr;</span>{" "}
+                {getPlayerName(hovered.kill.victimSteamId)}
+              </div>
+              <div className="text-muted-foreground">
+                {hovered.kill.weapon}
+                {hovered.kill.isHeadshot && (
+                  <span className="ml-1 text-yellow-400">(HS)</span>
+                )}
+              </div>
+              <div className="text-muted-foreground/60">Round {hovered.kill.roundNumber}</div>
+            </div>
+          )}
         </div>
+
+        {/* legend card */}
+        <Card className="w-full lg:w-auto">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Legend</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-xs text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <span className="inline-block h-3 w-3 rounded-full bg-team-ct shadow-[0_0_6px_rgba(91,155,213,0.5)]" />
+              <span>{teamAName} (CT)</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="inline-block h-3 w-3 rounded-full bg-team-t shadow-[0_0_6px_rgba(234,200,67,0.5)]" />
+              <span>{teamBName} (T)</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <svg width="12" height="12">
+                <circle cx="6" cy="6" r="4" fill="currentColor" opacity={0.6} />
+              </svg>
+              <span>Attacker position</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <svg width="12" height="12">
+                <line x1="2" y1="2" x2="10" y2="10" stroke="currentColor" strokeWidth="2" />
+                <line x1="10" y1="2" x2="2" y2="10" stroke="currentColor" strokeWidth="2" />
+              </svg>
+              <span>Victim position</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="inline-block h-3 w-3 rounded-full border-2 border-white bg-muted" />
+              <span>Headshot</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <svg width="20" height="2">
+                <line x1="0" y1="1" x2="20" y2="1" stroke="currentColor" strokeWidth="1" strokeDasharray="3 3" opacity={0.5} />
+              </svg>
+              <span>Kill line</span>
+            </div>
+            <div className="pt-1 tabular-nums text-muted-foreground/70">
+              {filtered.length} kill{filtered.length !== 1 ? "s" : ""} shown
+            </div>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/frontend/src/components/RoundTimeline.tsx
+++ b/frontend/src/components/RoundTimeline.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
 import type { RoundEvent, Player, WinMethod } from "../api/types";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Skull, Bomb, Shield, Clock, Crosshair, Trophy } from "lucide-react";
 
 interface RoundTimelineProps {
   rounds: RoundEvent[];
@@ -8,18 +12,19 @@ interface RoundTimelineProps {
   players: Player[];
 }
 
-function winMethodIcon(method: WinMethod): string {
+function WinMethodIcon({ method, className }: { method: WinMethod; className?: string }) {
+  const cls = className ?? "h-3 w-3";
   switch (method) {
     case "WIN_METHOD_ELIMINATION":
-      return "\u2620"; // skull
+      return <Skull className={cls} />;
     case "WIN_METHOD_BOMB_EXPLODED":
-      return "\uD83D\uDCA3"; // bomb
+      return <Bomb className={cls} />;
     case "WIN_METHOD_BOMB_DEFUSED":
-      return "\uD83D\uDEE1"; // shield
+      return <Shield className={cls} />;
     case "WIN_METHOD_TIME_EXPIRED":
-      return "\u23F1"; // timer
+      return <Clock className={cls} />;
     default:
-      return "?";
+      return null;
   }
 }
 
@@ -50,7 +55,7 @@ export function RoundTimeline({
 }: RoundTimelineProps) {
   const [selectedRound, setSelectedRound] = useState<number | null>(null);
 
-  // compute running score -- winner is "CT" or "T"
+  // running score
   let scoreA = 0;
   let scoreB = 0;
   const scores = rounds.map((r) => {
@@ -59,138 +64,216 @@ export function RoundTimeline({
     return { a: scoreA, b: scoreB };
   });
 
-  const selected = selectedRound !== null
-    ? rounds.find((r) => r.roundNumber === selectedRound)
-    : null;
+  const selected =
+    selectedRound !== null
+      ? rounds.find((r) => r.roundNumber === selectedRound)
+      : null;
+  const selectedIdx =
+    selectedRound !== null
+      ? rounds.findIndex((r) => r.roundNumber === selectedRound)
+      : -1;
 
   return (
-    <div>
-      {/* score legend */}
-      <div className="mb-4 flex items-center gap-4 text-sm">
-        <span className="flex items-center gap-1">
+    <div className="space-y-4">
+      {/* legend */}
+      <div className="flex items-center gap-6 text-sm">
+        <span className="flex items-center gap-1.5">
           <span className="inline-block h-3 w-3 rounded-sm bg-team-ct" />
           <span className="text-muted-foreground">{teamAName}</span>
         </span>
-        <span className="flex items-center gap-1">
+        <span className="flex items-center gap-1.5">
           <span className="inline-block h-3 w-3 rounded-sm bg-team-t" />
           <span className="text-muted-foreground">{teamBName}</span>
         </span>
+        <div className="flex items-center gap-3 text-xs text-muted-foreground/70">
+          <span className="flex items-center gap-1"><Skull className="h-3 w-3" /> Elim</span>
+          <span className="flex items-center gap-1"><Bomb className="h-3 w-3" /> Bomb</span>
+          <span className="flex items-center gap-1"><Shield className="h-3 w-3" /> Defuse</span>
+          <span className="flex items-center gap-1"><Clock className="h-3 w-3" /> Time</span>
+        </div>
       </div>
 
-      {/* round pills */}
-      <div className="flex flex-wrap gap-1">
-        {rounds.map((r, i) => {
-          const isTeamA = r.winner === "CT";
-          const bg = isTeamA ? "bg-team-ct" : "bg-team-t";
-          const isSelected = selectedRound === r.roundNumber;
+      {/* timeline - horizontal scroll */}
+      <div className="overflow-x-auto pb-2">
+        {/* score labels above */}
+        <div className="mb-1 flex items-center gap-0.5">
+          {scores.map((s, i) => {
+            const isHalf = rounds[i]?.roundNumber === 12;
+            return (
+              <div key={i} className="flex items-center gap-0.5">
+                <div className="flex w-10 flex-col items-center text-[10px] tabular-nums text-muted-foreground/60">
+                  <span>
+                    <span className="text-team-ct">{s.a}</span>
+                    <span className="text-muted-foreground/30">-</span>
+                    <span className="text-team-t">{s.b}</span>
+                  </span>
+                </div>
+                {isHalf && <div className="mx-0.5 w-px" />}
+              </div>
+            );
+          })}
+        </div>
 
-          return (
-            <button
-              key={r.roundNumber}
-              onClick={() =>
-                setSelectedRound(
-                  selectedRound === r.roundNumber ? null : r.roundNumber,
-                )
-              }
-              className={`flex h-10 w-10 flex-col items-center justify-center rounded text-xs font-medium transition-all ${bg} ${
-                isSelected ? "ring-2 ring-white ring-offset-2 ring-offset-background" : "opacity-80 hover:opacity-100"
-              }`}
-              title={`R${r.roundNumber}: ${scores[i]?.a}-${scores[i]?.b} (${winMethodLabel(r.winMethod)})`}
-            >
-              <span className="text-[10px] text-background font-bold">{r.roundNumber}</span>
-              <span className="text-[10px]">{winMethodIcon(r.winMethod)}</span>
-            </button>
-          );
-        })}
-      </div>
+        {/* round pills */}
+        <div className="flex items-center gap-0.5">
+          {rounds.map((r) => {
+            const isCT = r.winner === "CT";
+            const bg = isCT ? "bg-team-ct" : "bg-team-t";
+            const isSelected = selectedRound === r.roundNumber;
+            const isHalf = r.roundNumber === 12;
 
-      {/* score progression */}
-      <div className="mt-4 flex flex-wrap gap-1 text-xs text-muted-foreground">
-        {scores.map((s, i) => (
-          <span key={i} className="w-10 text-center">
-            {s.a}-{s.b}
-          </span>
-        ))}
+            return (
+              <div key={r.roundNumber} className="flex items-center gap-0.5">
+                <button
+                  onClick={() =>
+                    setSelectedRound(
+                      selectedRound === r.roundNumber ? null : r.roundNumber,
+                    )
+                  }
+                  className={`flex h-10 w-10 flex-col items-center justify-center rounded-md text-xs transition-all ${bg} ${
+                    isSelected
+                      ? "ring-2 ring-white ring-offset-2 ring-offset-background"
+                      : "opacity-75 hover:opacity-100"
+                  }`}
+                  title={`R${r.roundNumber}: ${winMethodLabel(r.winMethod)}`}
+                >
+                  <span className="text-[10px] font-bold leading-none text-background">
+                    {r.roundNumber}
+                  </span>
+                  <WinMethodIcon
+                    method={r.winMethod}
+                    className="mt-0.5 h-3 w-3 text-background/80"
+                  />
+                </button>
+                {isHalf && (
+                  <Separator orientation="vertical" className="mx-1 h-10 bg-muted-foreground/30" />
+                )}
+              </div>
+            );
+          })}
+        </div>
       </div>
 
       {/* round detail */}
-      {selected && (
-        <div className="mt-6 rounded-lg bg-muted p-4">
-          <h4 className="mb-3 font-semibold">
-            Round {selected.roundNumber} &mdash;{" "}
-            <span
-              className={
-                selected.winner === "CT" ? "text-team-ct" : "text-team-t"
-              }
-            >
-              {selected.winner}
-            </span>{" "}
-            ({winMethodLabel(selected.winMethod)})
-          </h4>
-
-          <div className="grid gap-3 text-sm sm:grid-cols-2">
-            {selected.firstKill && (
-              <div className="rounded bg-background p-3">
-                <div className="text-xs text-muted-foreground">First Kill</div>
-                <div>
-                  {playerName(selected.firstKill.attackerSteamId, players)}{" "}
-                  <span className="text-muted-foreground">&rarr;</span>{" "}
-                  {playerName(selected.firstKill.victimSteamId, players)}
-                </div>
-                {selected.firstKill.weapon && (
-                  <div className="text-xs text-muted-foreground">
-                    {selected.firstKill.weapon}
-                    {selected.firstKill.roundTime > 0 && ` at ${selected.firstKill.roundTime.toFixed(1)}s`}
-                  </div>
-                )}
-              </div>
-            )}
-
-            {selected.clutch && (
-              <div className="rounded bg-background p-3">
-                <div className="text-xs text-muted-foreground">Clutch</div>
-                <div>
-                  {playerName(selected.clutch.playerSteamId, players)} 1v
-                  {selected.clutch.opponentsAlive}
-                </div>
-                <div
-                  className={`text-xs ${selected.clutch.won ? "text-green-400" : "text-red-400"}`}
+      {selected && selectedIdx >= 0 && (
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-base">
+                Round {selected.roundNumber}
+              </CardTitle>
+              <div className="flex items-center gap-2">
+                <Badge
+                  className={
+                    selected.winner === "CT"
+                      ? "bg-team-ct/20 text-team-ct"
+                      : "bg-team-t/20 text-team-t"
+                  }
                 >
-                  {selected.clutch.won ? "Won" : "Lost"}
-                </div>
+                  {selected.winner === "CT" ? teamAName : teamBName} Win
+                </Badge>
+                <Badge variant="outline" className="gap-1">
+                  <WinMethodIcon method={selected.winMethod} className="h-3 w-3" />
+                  {winMethodLabel(selected.winMethod)}
+                </Badge>
               </div>
-            )}
-
-            {selected.plant && (
-              <div className="rounded bg-background p-3">
-                <div className="text-xs text-muted-foreground">Bomb Plant</div>
-                <div>
-                  {playerName(selected.plant.planterSteamId, players)} &rarr;
-                  Site {selected.plant.site}
-                </div>
-                {selected.plant.roundTime > 0 && (
-                  <div className="text-xs text-muted-foreground">
-                    at {selected.plant.roundTime.toFixed(1)}s
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {selected.firstKill && (
+                <div className="rounded-lg border border-border bg-muted/30 p-3">
+                  <div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Crosshair className="h-3 w-3" />
+                    First Kill
                   </div>
-                )}
-              </div>
-            )}
-
-            {selected.defuse && (
-              <div className="rounded bg-background p-3">
-                <div className="text-xs text-muted-foreground">Bomb Defuse</div>
-                <div>
-                  {playerName(selected.defuse.defuserSteamId, players)}
-                </div>
-                {selected.defuse.roundTime > 0 && (
-                  <div className="text-xs text-muted-foreground">
-                    at {selected.defuse.roundTime.toFixed(1)}s
+                  <div className="text-sm">
+                    <span className="font-medium">
+                      {playerName(selected.firstKill.attackerSteamId, players)}
+                    </span>
+                    <span className="mx-1.5 text-muted-foreground">&rarr;</span>
+                    <span className="font-medium">
+                      {playerName(selected.firstKill.victimSteamId, players)}
+                    </span>
                   </div>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
+                  {selected.firstKill.weapon && (
+                    <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                      <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                        {selected.firstKill.weapon}
+                      </Badge>
+                      {selected.firstKill.roundTime > 0 && (
+                        <span>{selected.firstKill.roundTime.toFixed(1)}s</span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {selected.clutch && (
+                <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-3">
+                  <div className="mb-1 flex items-center gap-1.5 text-xs text-yellow-400">
+                    <Trophy className="h-3 w-3" />
+                    Clutch
+                  </div>
+                  <div className="text-sm font-medium">
+                    {playerName(selected.clutch.playerSteamId, players)}
+                  </div>
+                  <div className="mt-1">
+                    <Badge
+                      className={
+                        selected.clutch.won
+                          ? "bg-green-500/20 text-green-400"
+                          : "bg-red-500/20 text-red-400"
+                      }
+                    >
+                      1v{selected.clutch.opponentsAlive}{" "}
+                      {selected.clutch.won ? "Won" : "Lost"}
+                    </Badge>
+                  </div>
+                </div>
+              )}
+
+              {selected.plant && (
+                <div className="rounded-lg border border-border bg-muted/30 p-3">
+                  <div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Bomb className="h-3 w-3" />
+                    Bomb Plant
+                  </div>
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className="font-medium">
+                      {playerName(selected.plant.planterSteamId, players)}
+                    </span>
+                    <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                      Site {selected.plant.site}
+                    </Badge>
+                  </div>
+                  {selected.plant.roundTime > 0 && (
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {selected.plant.roundTime.toFixed(1)}s
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {selected.defuse && (
+                <div className="rounded-lg border border-border bg-muted/30 p-3">
+                  <div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Shield className="h-3 w-3" />
+                    Bomb Defuse
+                  </div>
+                  <div className="text-sm font-medium">
+                    {playerName(selected.defuse.defuserSteamId, players)}
+                  </div>
+                  {selected.defuse.roundTime > 0 && (
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {selected.defuse.roundTime.toFixed(1)}s
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
       )}
     </div>
   );

--- a/frontend/src/components/Scoreboard.tsx
+++ b/frontend/src/components/Scoreboard.tsx
@@ -1,5 +1,17 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import type { PlayerStats } from "../api/types";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { ChevronUp, ChevronDown, Star } from "lucide-react";
 
 type SortKey = keyof Pick<
   PlayerStats,
@@ -10,9 +22,56 @@ interface ScoreboardProps {
   players: PlayerStats[];
   teamAName: string;
   teamBName: string;
+  teamAScore: number;
+  teamBScore: number;
 }
 
-export function Scoreboard({ players, teamAName, teamBName }: ScoreboardProps) {
+const columns: { key: SortKey; label: string; fmt?: (v: number) => string }[] = [
+  { key: "kills", label: "K" },
+  { key: "deaths", label: "D" },
+  { key: "assists", label: "A" },
+  { key: "adr", label: "ADR", fmt: (v) => v.toFixed(1) },
+  { key: "kast", label: "KAST%", fmt: (v) => v.toFixed(1) },
+  { key: "hsPct", label: "HS%", fmt: (v) => v.toFixed(1) },
+  { key: "rating", label: "Rating", fmt: (v) => v.toFixed(2) },
+];
+
+function kdColor(diff: number): string {
+  if (diff > 0) return "text-green-400";
+  if (diff < 0) return "text-red-400";
+  return "text-muted-foreground";
+}
+
+function adrColor(val: number): string {
+  if (val >= 80) return "text-green-400";
+  if (val >= 60) return "text-yellow-400";
+  return "text-red-400";
+}
+
+function ratingColor(val: number): string {
+  if (val > 1.0) return "text-green-400";
+  if (val >= 0.8) return "text-yellow-400";
+  return "text-red-400";
+}
+
+function cellColor(key: SortKey, val: number): string | undefined {
+  switch (key) {
+    case "adr":
+      return adrColor(val);
+    case "rating":
+      return ratingColor(val);
+    default:
+      return undefined;
+  }
+}
+
+export function Scoreboard({
+  players,
+  teamAName,
+  teamBName,
+  teamAScore,
+  teamBScore,
+}: ScoreboardProps) {
   const [sortKey, setSortKey] = useState<SortKey>("rating");
   const [sortAsc, setSortAsc] = useState(false);
 
@@ -25,73 +84,144 @@ export function Scoreboard({ players, teamAName, teamBName }: ScoreboardProps) {
     }
   };
 
-  const sorted = [...players].sort((a, b) => {
-    const diff = a[sortKey] - b[sortKey];
-    return sortAsc ? diff : -diff;
-  });
+  const sorted = useMemo(
+    () =>
+      [...players].sort((a, b) => {
+        const diff = a[sortKey] - b[sortKey];
+        return sortAsc ? diff : -diff;
+      }),
+    [players, sortKey, sortAsc],
+  );
 
   const teamA = sorted.filter((p) => p.team === "CT");
   const teamB = sorted.filter((p) => p.team === "T");
 
-  const columns: { key: SortKey; label: string; fmt?: (v: number) => string }[] = [
-    { key: "kills", label: "K" },
-    { key: "deaths", label: "D" },
-    { key: "assists", label: "A" },
-    { key: "adr", label: "ADR", fmt: (v) => v.toFixed(1) },
-    { key: "kast", label: "KAST%", fmt: (v) => v.toFixed(1) },
-    { key: "hsPct", label: "HS%", fmt: (v) => v.toFixed(1) },
-    { key: "rating", label: "Rating", fmt: (v) => v.toFixed(2) },
-  ];
+  // MVP is highest rated player overall
+  const mvpSteamId = useMemo(() => {
+    if (players.length === 0) return null;
+    return [...players].sort((a, b) => b.rating - a.rating)[0]?.steamId ?? null;
+  }, [players]);
 
-  const headerCell = (col: { key: SortKey; label: string }) => (
-    <th
-      key={col.key}
-      onClick={() => handleSort(col.key)}
-      className="cursor-pointer px-3 py-2 text-right text-xs font-medium text-muted-foreground hover:text-foreground"
-    >
-      {col.label}
-      {sortKey === col.key && (
-        <span className="ml-1">{sortAsc ? "\u25B2" : "\u25BC"}</span>
-      )}
-    </th>
-  );
+  const computeAverages = (team: PlayerStats[]) => {
+    if (team.length === 0) return null;
+    const n = team.length;
+    return {
+      adr: team.reduce((s, p) => s + p.adr, 0) / n,
+      kast: team.reduce((s, p) => s + p.kast, 0) / n,
+      hsPct: team.reduce((s, p) => s + p.hsPct, 0) / n,
+      rating: team.reduce((s, p) => s + p.rating, 0) / n,
+    };
+  };
 
-  const playerRow = (p: PlayerStats, teamColor: string) => (
-    <tr key={p.steamId} className="border-t border-border hover:bg-muted/50">
-      <td className="px-3 py-2">
-        <span className={teamColor}>{p.name}</span>
-      </td>
-      {columns.map((col) => (
-        <td key={col.key} className="px-3 py-2 text-right text-sm tabular-nums">
-          {col.fmt ? col.fmt(p[col.key]) : p[col.key]}
-        </td>
-      ))}
-    </tr>
-  );
-
-  const renderTeam = (team: PlayerStats[], name: string, color: string, textColor: string) => (
-    <div className="mb-6">
-      <div className={`mb-2 flex items-center gap-2 border-l-4 pl-3 ${color}`}>
-        <span className="font-semibold">{name}</span>
-      </div>
-      <table className="w-full">
-        <thead>
-          <tr className="border-b border-border">
-            <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">
-              Player
-            </th>
-            {columns.map(headerCell)}
-          </tr>
-        </thead>
-        <tbody>{team.map((p) => playerRow(p, textColor))}</tbody>
-      </table>
-    </div>
-  );
+  const renderTeam = (
+    team: PlayerStats[],
+    name: string,
+    score: number,
+    borderColor: string,
+    textColor: string,
+  ) => {
+    const avg = computeAverages(team);
+    return (
+      <Card>
+        <CardHeader className={`border-l-4 pb-3 ${borderColor}`}>
+          <div className="flex items-center justify-between">
+            <CardTitle className={`text-base ${textColor}`}>{name}</CardTitle>
+            <span className={`text-2xl font-bold tabular-nums ${textColor}`}>{score}</span>
+          </div>
+        </CardHeader>
+        <CardContent className="overflow-x-auto p-0">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="pl-4">Player</TableHead>
+                {columns.map((col) => (
+                  <TableHead
+                    key={col.key}
+                    className="cursor-pointer select-none text-right"
+                    onClick={() => handleSort(col.key)}
+                  >
+                    {col.label}
+                    {sortKey === col.key && (
+                      <span className="ml-0.5 inline-block align-middle">
+                        {sortAsc ? (
+                          <ChevronUp className="inline h-3 w-3" />
+                        ) : (
+                          <ChevronDown className="inline h-3 w-3" />
+                        )}
+                      </span>
+                    )}
+                  </TableHead>
+                ))}
+                <TableHead className="text-right">+/-</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {team.map((p) => {
+                const kd = p.kills - p.deaths;
+                const isMvp = p.steamId === mvpSteamId;
+                return (
+                  <TableRow key={p.steamId}>
+                    <TableCell className="pl-4">
+                      <span className={`font-medium ${textColor}`}>{p.name}</span>
+                      {isMvp && (
+                        <Badge
+                          variant="outline"
+                          className="ml-2 border-yellow-500/50 px-1.5 py-0 text-[10px] text-yellow-400"
+                        >
+                          <Star className="mr-0.5 inline h-2.5 w-2.5" />
+                          MVP
+                        </Badge>
+                      )}
+                    </TableCell>
+                    {columns.map((col) => (
+                      <TableCell
+                        key={col.key}
+                        className={`text-right tabular-nums ${cellColor(col.key, p[col.key]) ?? ""}`}
+                      >
+                        {col.fmt ? col.fmt(p[col.key]) : p[col.key]}
+                      </TableCell>
+                    ))}
+                    <TableCell className={`text-right tabular-nums ${kdColor(kd)}`}>
+                      {kd > 0 ? `+${kd}` : kd}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+            {avg && (
+              <TableFooter>
+                <TableRow className="hover:bg-transparent">
+                  <TableCell className="pl-4 text-xs text-muted-foreground">Average</TableCell>
+                  {/* K, D, A columns empty */}
+                  <TableCell />
+                  <TableCell />
+                  <TableCell />
+                  <TableCell className={`text-right tabular-nums text-xs ${adrColor(avg.adr)}`}>
+                    {avg.adr.toFixed(1)}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums text-xs">
+                    {avg.kast.toFixed(1)}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums text-xs">
+                    {avg.hsPct.toFixed(1)}
+                  </TableCell>
+                  <TableCell className={`text-right tabular-nums text-xs ${ratingColor(avg.rating)}`}>
+                    {avg.rating.toFixed(2)}
+                  </TableCell>
+                  <TableCell />
+                </TableRow>
+              </TableFooter>
+            )}
+          </Table>
+        </CardContent>
+      </Card>
+    );
+  };
 
   return (
-    <div className="overflow-x-auto">
-      {renderTeam(teamA, teamAName, "border-team-ct", "text-team-ct")}
-      {renderTeam(teamB, teamBName, "border-team-t", "text-team-t")}
+    <div className="space-y-4">
+      {renderTeam(teamA, teamAName, teamAScore, "border-team-ct", "text-team-ct")}
+      {renderTeam(teamB, teamBName, teamBScore, "border-team-t", "text-team-t")}
     </div>
   );
 }

--- a/frontend/src/components/skeletons.tsx
+++ b/frontend/src/components/skeletons.tsx
@@ -63,24 +63,26 @@ export function TableRowSkeleton({ columns = 5 }: { columns?: number }) {
 
 export function MatchTableSkeleton() {
   return (
-    <div className="overflow-x-auto rounded-lg border border-border">
-      <table className="w-full">
-        <thead>
-          <tr className="border-b border-border bg-muted/50">
-            {["Map", "Date", "Teams", "Score", "Duration"].map((h) => (
-              <th key={h} className="px-4 py-3 text-left text-xs font-medium text-muted-foreground">
-                {h}
-              </th>
+    <Card>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-border">
+              {["Map", "Date", "Teams", "Score", "Duration"].map((h) => (
+                <th key={h} className="h-10 px-2 text-left text-sm font-medium text-muted-foreground">
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 8 }, (_, i) => (
+              <TableRowSkeleton key={i} />
             ))}
-          </tr>
-        </thead>
-        <tbody>
-          {Array.from({ length: 8 }, (_, i) => (
-            <TableRowSkeleton key={i} />
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </tbody>
+        </table>
+      </div>
+    </Card>
   );
 }
 
@@ -89,15 +91,20 @@ export function MatchDetailSkeleton() {
     <div className="space-y-6">
       <Card>
         <CardContent className="p-6">
-          <Skeleton className="mb-2 h-4 w-32" />
-          <div className="flex items-center gap-4">
-            <Skeleton className="h-8 w-36" />
-            <Skeleton className="h-10 w-20" />
-            <Skeleton className="h-8 w-36" />
+          <Skeleton className="mb-4 h-6 w-32" />
+          <div className="flex items-center justify-center gap-6 py-4">
+            <Skeleton className="h-8 w-28" />
+            <div className="flex items-baseline gap-3">
+              <Skeleton className="h-12 w-12" />
+              <Skeleton className="h-6 w-4" />
+              <Skeleton className="h-12 w-12" />
+            </div>
+            <Skeleton className="h-8 w-28" />
           </div>
-          <div className="mt-2 flex gap-4">
-            <Skeleton className="h-4 w-20" />
+          <div className="mt-2 flex justify-center gap-4">
+            <Skeleton className="h-4 w-32" />
             <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-24" />
           </div>
         </CardContent>
       </Card>
@@ -117,16 +124,27 @@ export function MatchDetailSkeleton() {
 
 export function ScoreboardSkeleton() {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {[0, 1].map((team) => (
-        <div key={team} className="space-y-2">
-          <Skeleton className="h-6 w-40" />
-          <div className="space-y-1">
-            {Array.from({ length: 5 }, (_, i) => (
-              <Skeleton key={i} className="h-10 w-full" />
-            ))}
-          </div>
-        </div>
+        <Card key={team}>
+          <CardHeader className="pb-3">
+            <Skeleton className="h-6 w-40" />
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="space-y-0">
+              {Array.from({ length: 5 }, (_, i) => (
+                <div key={i} className="flex gap-2 border-b border-border px-4 py-2">
+                  <Skeleton className="h-5 w-24" />
+                  <div className="flex flex-1 justify-end gap-4">
+                    {Array.from({ length: 8 }, (_, j) => (
+                      <Skeleton key={j} className="h-5 w-8" />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
       ))}
     </div>
   );

--- a/frontend/src/pages/MatchList.tsx
+++ b/frontend/src/pages/MatchList.tsx
@@ -1,11 +1,30 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Link } from "@tanstack/react-router";
 import { useListMatches } from "../api/queries";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
 import { MatchTableSkeleton } from "@/components/skeletons";
+import {
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+  Filter,
+  ChevronRight,
+  X,
+  Swords,
+} from "lucide-react";
+import type { Match } from "../api/types";
 
 const MAPS = [
   "de_dust2",
@@ -18,9 +37,33 @@ const MAPS = [
   "de_anubis",
 ];
 
+function formatRelativeTime(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diffSec = Math.floor((now - then) / 1000);
+
+  if (diffSec < 60) return "just now";
+  if (diffSec < 3600) {
+    const m = Math.floor(diffSec / 60);
+    return `${m}m ago`;
+  }
+  if (diffSec < 86400) {
+    const h = Math.floor(diffSec / 3600);
+    return `${h}h ago`;
+  }
+  if (diffSec < 604800) {
+    const d = Math.floor(diffSec / 86400);
+    return `${d}d ago`;
+  }
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
 function formatDate(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleDateString("en-US", {
+  return new Date(iso).toLocaleDateString("en-US", {
     year: "numeric",
     month: "short",
     day: "numeric",
@@ -35,11 +78,51 @@ function formatDuration(seconds: number): string {
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
+type SortField = "mapName" | "date" | "durationSeconds" | "score";
+type SortDir = "asc" | "desc";
+
+function matchScore(m: Match): number {
+  return m.teamAScore + m.teamBScore;
+}
+
+function compareMatches(a: Match, b: Match, field: SortField, dir: SortDir): number {
+  let diff = 0;
+  switch (field) {
+    case "mapName":
+      diff = a.mapName.localeCompare(b.mapName);
+      break;
+    case "date":
+      diff = new Date(a.date).getTime() - new Date(b.date).getTime();
+      break;
+    case "durationSeconds":
+      diff = a.durationSeconds - b.durationSeconds;
+      break;
+    case "score":
+      diff = matchScore(a) - matchScore(b);
+      break;
+  }
+  return dir === "asc" ? diff : -diff;
+}
+
+function SortIcon({ field, sortField, sortDir }: { field: SortField; sortField: SortField; sortDir: SortDir }) {
+  if (field !== sortField) {
+    return <ChevronsUpDown className="ml-1 inline h-3 w-3 text-muted-foreground/50" />;
+  }
+  return sortDir === "asc" ? (
+    <ChevronUp className="ml-1 inline h-3 w-3" />
+  ) : (
+    <ChevronDown className="ml-1 inline h-3 w-3" />
+  );
+}
+
 export function MatchList() {
   const [mapFilter, setMapFilter] = useState("");
   const [playerSearch, setPlayerSearch] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
+  const [filtersOpen, setFiltersOpen] = useState(true);
+  const [sortField, setSortField] = useState<SortField>("date");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, error } =
     useListMatches({
@@ -52,67 +135,112 @@ export function MatchList() {
   const matches = data?.pages.flatMap((p) => p.matches) ?? [];
   const hasFilters = mapFilter || playerSearch || dateFrom || dateTo;
 
+  const sorted = useMemo(
+    () => [...matches].sort((a, b) => compareMatches(a, b, sortField, sortDir)),
+    [matches, sortField, sortDir],
+  );
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDir("desc");
+    }
+  };
+
+  const clearFilters = () => {
+    setMapFilter("");
+    setPlayerSearch("");
+    setDateFrom("");
+    setDateTo("");
+  };
+
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-bold">Matches</h1>
-
-      {/* filters */}
-      <div className="mb-6 flex flex-wrap gap-3">
-        <Select
-          value={mapFilter}
-          onChange={(e) => setMapFilter(e.target.value)}
-          className="w-auto"
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Matches</h1>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setFiltersOpen(!filtersOpen)}
+          className="gap-1.5 text-muted-foreground"
         >
-          <option value="">All Maps</option>
-          {MAPS.map((m) => (
-            <option key={m} value={m}>
-              {m}
-            </option>
-          ))}
-        </Select>
-
-        <Input
-          type="text"
-          placeholder="Player Steam ID..."
-          value={playerSearch}
-          onChange={(e) => setPlayerSearch(e.target.value)}
-          className="w-auto max-w-[200px]"
-        />
-
-        <Input
-          type="date"
-          value={dateFrom}
-          onChange={(e) => setDateFrom(e.target.value)}
-          className="w-auto"
-        />
-
-        <Input
-          type="date"
-          value={dateTo}
-          onChange={(e) => setDateTo(e.target.value)}
-          className="w-auto"
-        />
-
-        {hasFilters && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              setMapFilter("");
-              setPlayerSearch("");
-              setDateFrom("");
-              setDateTo("");
-            }}
-          >
-            Clear
-          </Button>
-        )}
+          <Filter className="h-4 w-4" />
+          Filters
+          <ChevronRight
+            className={`h-3 w-3 transition-transform ${filtersOpen ? "rotate-90" : ""}`}
+          />
+        </Button>
       </div>
 
-      {/* loading state */}
+      {/* collapsible filters */}
+      {filtersOpen && (
+        <Card className="mb-6">
+          <CardContent className="p-4">
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">Map</label>
+                <Select
+                  value={mapFilter}
+                  onChange={(e) => setMapFilter(e.target.value)}
+                  className="w-[160px]"
+                >
+                  <option value="">All Maps</option>
+                  {MAPS.map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">Player Steam ID</label>
+                <Input
+                  type="text"
+                  placeholder="Search..."
+                  value={playerSearch}
+                  onChange={(e) => setPlayerSearch(e.target.value)}
+                  className="w-[180px]"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">From</label>
+                <Input
+                  type="date"
+                  value={dateFrom}
+                  onChange={(e) => setDateFrom(e.target.value)}
+                  className="w-[150px]"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">To</label>
+                <Input
+                  type="date"
+                  value={dateTo}
+                  onChange={(e) => setDateTo(e.target.value)}
+                  className="w-[150px]"
+                />
+              </div>
+
+              {hasFilters && (
+                <Button variant="ghost" size="sm" onClick={clearFilters} className="gap-1">
+                  <X className="h-3 w-3" />
+                  Clear
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* loading */}
       {isLoading && <MatchTableSkeleton />}
 
-      {/* error state */}
+      {/* error */}
       {isError && (
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
           {error.message}
@@ -120,78 +248,134 @@ export function MatchList() {
       )}
 
       {/* empty state */}
-      {!isLoading && matches.length === 0 && (
-        <div className="rounded-lg border border-border bg-card py-12 text-center text-muted-foreground">
-          No matches found. Upload a demo to get started.
-        </div>
+      {!isLoading && !isError && matches.length === 0 && (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-16">
+            <Swords className="mb-4 h-12 w-12 text-muted-foreground/40" />
+            <p className="text-lg font-medium text-muted-foreground">
+              {hasFilters ? "No matches found" : "No matches yet"}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground/70">
+              {hasFilters
+                ? "Try adjusting your filters"
+                : "Upload a demo to get started"}
+            </p>
+          </CardContent>
+        </Card>
       )}
 
       {/* match table */}
-      {matches.length > 0 && (
-        <div className="overflow-x-auto rounded-lg border border-border">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-border bg-muted/50">
-                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground">
-                  Map
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground">
-                  Date
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground">
-                  Teams
-                </th>
-                <th className="px-4 py-3 text-center text-xs font-medium text-muted-foreground">
-                  Score
-                </th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground">
-                  Duration
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {matches.map((m) => (
-                <tr
-                  key={m.id}
-                  className="border-t border-border transition-colors hover:bg-muted/50"
+      {sorted.length > 0 && (
+        <Card>
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead
+                  className="cursor-pointer select-none"
+                  onClick={() => handleSort("mapName")}
                 >
-                  <td className="px-4 py-3">
-                    <Link
-                      to="/matches/$matchId"
-                      params={{ matchId: m.id }}
-                      className="font-medium text-foreground hover:text-team-ct transition-colors"
-                    >
-                      <Badge variant="secondary" className="font-mono text-xs">
-                        {m.mapName.replace("de_", "")}
-                      </Badge>
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground">
-                    {formatDate(m.date)}
-                  </td>
-                  <td className="px-4 py-3 text-sm">
-                    <span className="text-team-ct">{m.teamAName}</span>
-                    <span className="mx-2 text-muted-foreground/50">vs</span>
-                    <span className="text-team-t">{m.teamBName}</span>
-                  </td>
-                  <td className="px-4 py-3 text-center tabular-nums">
-                    <span className="text-team-ct">{m.teamAScore}</span>
-                    <span className="mx-1 text-muted-foreground/50">:</span>
-                    <span className="text-team-t">{m.teamBScore}</span>
-                  </td>
-                  <td className="px-4 py-3 text-right text-sm text-muted-foreground tabular-nums">
-                    {formatDuration(m.durationSeconds)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                  Map
+                  <SortIcon field="mapName" sortField={sortField} sortDir={sortDir} />
+                </TableHead>
+                <TableHead
+                  className="cursor-pointer select-none"
+                  onClick={() => handleSort("date")}
+                >
+                  Date
+                  <SortIcon field="date" sortField={sortField} sortDir={sortDir} />
+                </TableHead>
+                <TableHead>Teams</TableHead>
+                <TableHead
+                  className="cursor-pointer select-none text-center"
+                  onClick={() => handleSort("score")}
+                >
+                  Score
+                  <SortIcon field="score" sortField={sortField} sortDir={sortDir} />
+                </TableHead>
+                <TableHead
+                  className="cursor-pointer select-none text-right"
+                  onClick={() => handleSort("durationSeconds")}
+                >
+                  Duration
+                  <SortIcon field="durationSeconds" sortField={sortField} sortDir={sortDir} />
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sorted.map((m) => {
+                const aWon = m.teamAScore > m.teamBScore;
+                const bWon = m.teamBScore > m.teamAScore;
+                return (
+                  <TableRow key={m.id} className="group">
+                    <TableCell>
+                      <Link
+                        to="/matches/$matchId"
+                        params={{ matchId: m.id }}
+                        className="inline-block"
+                      >
+                        <Badge variant="secondary" className="font-mono text-xs transition-colors group-hover:bg-primary/20">
+                          {m.mapName.replace("de_", "")}
+                        </Badge>
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      <Link
+                        to="/matches/$matchId"
+                        params={{ matchId: m.id }}
+                        className="block"
+                      >
+                        <span className="text-sm text-foreground">{formatRelativeTime(m.date)}</span>
+                        <span className="ml-2 hidden text-xs text-muted-foreground/70 sm:inline">
+                          {formatDate(m.date)}
+                        </span>
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      <Link
+                        to="/matches/$matchId"
+                        params={{ matchId: m.id }}
+                        className="block text-sm"
+                      >
+                        <span className="text-team-ct">{m.teamAName}</span>
+                        <span className="mx-2 text-muted-foreground/40">vs</span>
+                        <span className="text-team-t">{m.teamBName}</span>
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <Link
+                        to="/matches/$matchId"
+                        params={{ matchId: m.id }}
+                        className="block tabular-nums"
+                      >
+                        <span className={`text-team-ct ${aWon ? "font-bold" : ""}`}>
+                          {m.teamAScore}
+                        </span>
+                        <span className="mx-1 text-muted-foreground/40">:</span>
+                        <span className={`text-team-t ${bWon ? "font-bold" : ""}`}>
+                          {m.teamBScore}
+                        </span>
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Link
+                        to="/matches/$matchId"
+                        params={{ matchId: m.id }}
+                        className="block text-sm tabular-nums text-muted-foreground"
+                      >
+                        {formatDuration(m.durationSeconds)}
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </Card>
       )}
 
       {/* load more */}
       {hasNextPage && (
-        <div className="mt-4 text-center">
+        <div className="mt-4 flex justify-center gap-2">
           <Button
             variant="outline"
             onClick={() => void fetchNextPage()}


### PR DESCRIPTION
Closes #13

Spec: .manager/specs/013-cs2stats-match-views-overhaul.md

## Changes
- **Match list**: Sortable columns, collapsible filters, relative dates, shadcn Table, empty state with icon
- **Match detail**: Prominent map name, winning score emphasis, copy-to-clipboard demo hash with toast
- **Scoreboard**: Team Cards with colored borders, +/- column, ADR/rating color coding, MVP star badge, summary footer row
- **Round timeline**: Lucide icons for win methods, half-time separator, running scores, detailed round event cards with badges
- **Economy chart**: Area gradients, Card wrappers, shadcn Table for buy types, colored badges
- **Kill map**: Glow filters on attacker dots, dotted kill lines, responsive SVG, legend card
- **Skeletons**: Updated to match new component layouts

7 files changed, 1176 insertions, 627 deletions.