### PR TITLE
016: Fix Data Coherence — Steam IDs, Scores, Team Identity

### DIFF
--- a/proto/demo/v1/demo.proto
+++ b/proto/demo/v1/demo.proto
@@ -62,6 +62,7 @@ message Match {
   int32 team_a_score = 7;
   int32 team_b_score = 8;
   string demo_file_hash = 9;
+  string team_a_started_as = 10;
 }
 
 message Player {

--- a/repository/migrations/003_kill_steam_ids_and_team_identity.sql
+++ b/repository/migrations/003_kill_steam_ids_and_team_identity.sql
@@ -1,0 +1,4 @@
+ALTER TABLE kill_events ADD COLUMN attacker_steam_id TEXT;
+ALTER TABLE kill_events ADD COLUMN victim_steam_id TEXT;
+ALTER TABLE clutches ADD COLUMN player_steam_id TEXT;
+ALTER TABLE matches ADD COLUMN team_a_started_as TEXT DEFAULT 'CT';

--- a/repository/sqlite_test.go
+++ b/repository/sqlite_test.go
@@ -29,6 +29,7 @@ func seedMatch(t *testing.T, repo *SQLite) Match {
 		ScoreA:          16,
 		ScoreB:          12,
 		DemoHash:        "abc123hash",
+		TeamAStartedAs:  "CT",
 		CreatedAt:       now,
 		Players: []PlayerStats{
 			{
@@ -59,7 +60,7 @@ func seedMatch(t *testing.T, repo *SQLite) Match {
 				BombPlantSteamID: "76561198002", BombPlantSite: "B",
 				BombPlantRoundTime: 35.2,
 				Clutch: &Clutch{
-					RoundID: "r2", PlayerID: "p2", Opponents: 2, Success: true,
+					RoundID: "r2", PlayerID: "p2", PlayerSteamID: "76561198002", Opponents: 2, Success: true,
 				},
 			},
 		},
@@ -72,12 +73,14 @@ func seedMatch(t *testing.T, repo *SQLite) Match {
 		KillEvents: []KillEvent{
 			{
 				ID: "k1", RoundID: "r1", Attacker: "p1", Victim: "p2",
+				AttackerSteamID: "76561198001", VictimSteamID: "76561198002",
 				Weapon: "AK-47", Headshot: true,
 				AttackerX: 100.5, AttackerY: 200.3, AttackerZ: 10.0,
 				VictimX: 300.1, VictimY: 400.2, VictimZ: 10.0,
 			},
 			{
 				ID: "k2", RoundID: "r2", Attacker: "p2", Victim: "p1",
+				AttackerSteamID: "76561198002", VictimSteamID: "76561198001",
 				Weapon: "AWP", Headshot: false,
 				AttackerX: 150.0, AttackerY: 250.0, AttackerZ: 12.0,
 				VictimX: 350.0, VictimY: 450.0, VictimZ: 12.0,
@@ -124,6 +127,9 @@ func TestStoreAndGetMatch(t *testing.T) {
 	}
 	if got.DemoHash != want.DemoHash {
 		t.Errorf("DemoHash: got %s, want %s", got.DemoHash, want.DemoHash)
+	}
+	if got.TeamAStartedAs != "CT" {
+		t.Errorf("TeamAStartedAs: got %s, want CT", got.TeamAStartedAs)
 	}
 }
 
@@ -321,6 +327,9 @@ func TestGetRounds(t *testing.T) {
 	if r2.Clutch.Opponents != 2 {
 		t.Errorf("clutch opponents: got %d, want 2", r2.Clutch.Opponents)
 	}
+	if r2.Clutch.PlayerSteamID != "76561198002" {
+		t.Errorf("clutch player steam ID: got %s, want 76561198002", r2.Clutch.PlayerSteamID)
+	}
 	if r2.BombPlantSteamID != "76561198002" {
 		t.Errorf("round 2 bomb plant steam ID: got %s, want 76561198002", r2.BombPlantSteamID)
 	}
@@ -381,10 +390,22 @@ func TestGetKillPositions(t *testing.T) {
 	if k1.AttackerX != 100.5 {
 		t.Errorf("kill 1 attacker X: got %f, want 100.5", k1.AttackerX)
 	}
+	if k1.AttackerSteamID != "76561198001" {
+		t.Errorf("kill 1 attacker steam ID: got %s, want 76561198001", k1.AttackerSteamID)
+	}
+	if k1.VictimSteamID != "76561198002" {
+		t.Errorf("kill 1 victim steam ID: got %s, want 76561198002", k1.VictimSteamID)
+	}
 
 	k2 := kills[1]
 	if k2.Headshot {
 		t.Error("kill 2 should not be headshot")
+	}
+	if k2.AttackerSteamID != "76561198002" {
+		t.Errorf("kill 2 attacker steam ID: got %s, want 76561198002", k2.AttackerSteamID)
+	}
+	if k2.VictimSteamID != "76561198001" {
+		t.Errorf("kill 2 victim steam ID: got %s, want 76561198001", k2.VictimSteamID)
 	}
 }
 

--- a/repository/types.go
+++ b/repository/types.go
@@ -13,6 +13,7 @@ type Match struct {
 	ScoreA          int
 	ScoreB          int
 	DemoHash        string
+	TeamAStartedAs  string
 	CreatedAt       time.Time
 	Players         []PlayerStats
 	Rounds          []Round
@@ -30,6 +31,7 @@ type MatchSummary struct {
 	TeamB           string
 	ScoreA          int
 	ScoreB          int
+	TeamAStartedAs  string
 	CreatedAt       time.Time
 }
 
@@ -92,10 +94,11 @@ type Round struct {
 
 // Clutch records a clutch attempt in a round.
 type Clutch struct {
-	RoundID   string
-	PlayerID  string
-	Opponents int
-	Success   bool
+	RoundID       string
+	PlayerID      string
+	PlayerSteamID string
+	Opponents     int
+	Success       bool
 }
 
 // EconomyRound holds economy data for one team in one round.
@@ -111,18 +114,20 @@ type EconomyRound struct {
 
 // KillEvent records a single kill with positional data.
 type KillEvent struct {
-	ID        string
-	RoundID   string
-	MatchID   string
-	RoundNum  int
-	Attacker  string // player ID
-	Victim    string // player ID
-	Weapon    string
-	Headshot  bool
-	AttackerX float64
-	AttackerY float64
-	AttackerZ float64
-	VictimX   float64
-	VictimY   float64
-	VictimZ   float64
+	ID              string
+	RoundID         string
+	MatchID         string
+	RoundNum        int
+	Attacker        string // player ID
+	Victim          string // player ID
+	AttackerSteamID string
+	VictimSteamID   string
+	Weapon          string
+	Headshot        bool
+	AttackerX       float64
+	AttackerY       float64
+	AttackerZ       float64
+	VictimX         float64
+	VictimY         float64
+	VictimZ         float64
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -115,7 +115,7 @@ func seedViaRepo(t *testing.T, repo *repository.SQLite) string {
 		Date: now, DurationSeconds: 2100,
 		TeamA: "Astralis", TeamB: "Liquid",
 		ScoreA: 16, ScoreB: 14,
-		DemoHash: "seed-hash-123", CreatedAt: now,
+		DemoHash: "seed-hash-123", TeamAStartedAs: "CT", CreatedAt: now,
 		Players: []repository.PlayerStats{
 			{
 				PlayerID: "pid1", SteamID: "76561198001", Name: "device",
@@ -139,7 +139,7 @@ func seedViaRepo(t *testing.T, repo *repository.SQLite) string {
 				ID: "rd2", Number: 2, WinnerTeam: "T", WinMethod: "BombExploded",
 				FirstKillPlayerID: "pid2", FirstDeathPlayerID: "pid1",
 				Clutch: &repository.Clutch{
-					RoundID: "rd2", PlayerID: "pid2", Opponents: 3, Success: false,
+					RoundID: "rd2", PlayerID: "pid2", PlayerSteamID: "76561198002", Opponents: 3, Success: false,
 				},
 			},
 		},
@@ -152,6 +152,7 @@ func seedViaRepo(t *testing.T, repo *repository.SQLite) string {
 		KillEvents: []repository.KillEvent{
 			{
 				ID: "ke1", RoundID: "rd1", Attacker: "pid1", Victim: "pid2",
+				AttackerSteamID: "76561198001", VictimSteamID: "76561198002",
 				Weapon: "M4A4", Headshot: true,
 				AttackerX: 50, AttackerY: 60, AttackerZ: 5,
 				VictimX: 150, VictimY: 160, VictimZ: 5,

--- a/service/types.go
+++ b/service/types.go
@@ -13,6 +13,7 @@ type MatchDetail struct {
 	ScoreA          int
 	ScoreB          int
 	DemoHash        string
+	TeamAStartedAs  string
 }
 
 // MatchSummary is a lightweight listing entry.
@@ -26,6 +27,7 @@ type MatchSummary struct {
 	ScoreA          int
 	ScoreB          int
 	DemoHash        string
+	TeamAStartedAs  string
 	CreatedAt       time.Time
 }
 
@@ -88,9 +90,10 @@ type DefuseEvent struct {
 
 // ClutchEvent describes a clutch attempt.
 type ClutchEvent struct {
-	PlayerID  string
-	Opponents int
-	Success   bool
+	PlayerID      string
+	PlayerSteamID string
+	Opponents     int
+	Success       bool
 }
 
 // EconomyData holds economy info for one team in one round.
@@ -104,15 +107,17 @@ type EconomyData struct {
 
 // KillPosition holds a kill event with positional data.
 type KillPosition struct {
-	RoundNumber int
-	AttackerID  string
-	VictimID    string
-	Weapon      string
-	Headshot    bool
-	AttackerX   float64
-	AttackerY   float64
-	AttackerZ   float64
-	VictimX     float64
-	VictimY     float64
-	VictimZ     float64
+	RoundNumber     int
+	AttackerID      string
+	VictimID        string
+	AttackerSteamID string
+	VictimSteamID   string
+	Weapon          string
+	Headshot        bool
+	AttackerX       float64
+	AttackerY       float64
+	AttackerZ       float64
+	VictimX         float64
+	VictimY         float64
+	VictimZ         float64
 }

--- a/transport/grpc/mapping.go
+++ b/transport/grpc/mapping.go
@@ -50,6 +50,7 @@ func matchDetailToProto(m service.MatchDetail) *demov1.Match {
 		TeamAScore:      int32(m.ScoreA),
 		TeamBScore:      int32(m.ScoreB),
 		DemoFileHash:    m.DemoHash,
+		TeamAStartedAs:  m.TeamAStartedAs,
 	}
 }
 
@@ -64,6 +65,7 @@ func matchSummaryToProto(m service.MatchSummary) *demov1.Match {
 		TeamAScore:      int32(m.ScoreA),
 		TeamBScore:      int32(m.ScoreB),
 		DemoFileHash:    m.DemoHash,
+		TeamAStartedAs:  m.TeamAStartedAs,
 	}
 }
 
@@ -185,7 +187,7 @@ func roundEventToProto(r service.RoundEvent) *statsv1.RoundEvent {
 	}
 	if r.Clutch != nil {
 		pe.Clutch = &statsv1.ClutchInfo{
-			PlayerSteamId:  r.Clutch.PlayerID,
+			PlayerSteamId:  r.Clutch.PlayerSteamID,
 			OpponentsAlive: int32(r.Clutch.Opponents),
 			Won:            r.Clutch.Success,
 		}
@@ -211,8 +213,8 @@ func parseWinMethod(s string) statsv1.WinMethod {
 func killPositionToProto(k service.KillPosition) *statsv1.KillPosition {
 	return &statsv1.KillPosition{
 		RoundNumber:     int32(k.RoundNumber),
-		AttackerSteamId: k.AttackerID,
-		VictimSteamId:   k.VictimID,
+		AttackerSteamId: k.AttackerSteamID,
+		VictimSteamId:   k.VictimSteamID,
 		Weapon:          k.Weapon,
 		IsHeadshot:      k.Headshot,
 		AttackerPos: &statsv1.Position{


### PR DESCRIPTION
Closes #21

Spec: .manager/specs/016-cs2stats-data-coherence.md

## Changes
- **Kill positions**: Added `attacker_steam_id`/`victim_steam_id` columns — API now returns real Steam IDs instead of internal UUIDs
- **Clutch events**: Added `player_steam_id` column — API returns Steam ID instead of UUID
- **Team identity**: Added `team_a_started_as` field to proto Match message and all layers, so frontend can correctly map CT/T round winners to TeamA/TeamB
- **Score coherence**: Computes match scores from per-round winners to ensure match header always matches round timeline
- **Migration 003**: New columns on `kill_events`, `clutches`, and `matches` tables

9 files changed, 157 insertions, 84 deletions.