### PR TITLE
017: Frontend Vision — Insight-Driven Stats Experience

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -13,6 +13,7 @@ export interface Match {
   teamAScore: number;
   teamBScore: number;
   demoFileHash: string;
+  teamAStartedAs: string;
 }
 
 export interface Player {

--- a/frontend/src/components/KillMap.tsx
+++ b/frontend/src/components/KillMap.tsx
@@ -186,6 +186,12 @@ export function KillMap({
               const vp = normalize(k.victimPos.x, k.victimPos.y);
               const aColor = teamColor(k.attackerSteamId);
               const vColor = teamColor(k.victimSteamId);
+              // when a player filter is active, dim kills that don't involve the selected player as attacker
+              const isPlayerFiltered = filterPlayer !== "";
+              const isHighlighted = !isPlayerFiltered || k.attackerSteamId === filterPlayer;
+              const baseOpacity = isHighlighted ? 0.9 : 0.08;
+              const lineOpacity = isHighlighted ? 0.4 : 0.05;
+              const dotRadius = isHighlighted && isPlayerFiltered ? (k.isHeadshot ? 6 : 5) : (k.isHeadshot ? 5 : 4);
               return (
                 <g key={i}>
                   {/* dotted line */}
@@ -194,18 +200,18 @@ export function KillMap({
                     stroke="hsl(215 15% 30%)"
                     strokeWidth={0.8}
                     strokeDasharray="3 3"
-                    opacity={0.4}
+                    opacity={lineOpacity}
                   />
                   {/* attacker dot with glow */}
                   <circle
                     cx={ap.nx} cy={ap.ny}
-                    r={k.isHeadshot ? 5 : 4}
+                    r={dotRadius}
                     fill={aColor}
-                    opacity={0.9}
-                    filter="url(#glow)"
+                    opacity={baseOpacity}
+                    filter={isHighlighted ? "url(#glow)" : undefined}
                     stroke={k.isHeadshot ? "#fff" : aColor}
                     strokeWidth={k.isHeadshot ? 1.5 : 0.5}
-                    strokeOpacity={k.isHeadshot ? 0.8 : 0.3}
+                    strokeOpacity={isHighlighted ? (k.isHeadshot ? 0.8 : 0.3) : 0.05}
                     onMouseEnter={() => setHovered({ kill: k, x: ap.nx, y: ap.ny })}
                     onMouseLeave={() => setHovered(null)}
                     className="cursor-pointer"
@@ -218,11 +224,11 @@ export function KillMap({
                   >
                     <line
                       x1={vp.nx - 4} y1={vp.ny - 4} x2={vp.nx + 4} y2={vp.ny + 4}
-                      stroke={vColor} strokeWidth={2} opacity={0.8}
+                      stroke={vColor} strokeWidth={2} opacity={isHighlighted ? 0.8 : 0.08}
                     />
                     <line
                       x1={vp.nx + 4} y1={vp.ny - 4} x2={vp.nx - 4} y2={vp.ny + 4}
-                      stroke={vColor} strokeWidth={2} opacity={0.8}
+                      stroke={vColor} strokeWidth={2} opacity={isHighlighted ? 0.8 : 0.08}
                     />
                   </g>
                 </g>

--- a/frontend/src/components/Scoreboard.tsx
+++ b/frontend/src/components/Scoreboard.tsx
@@ -11,7 +11,7 @@ import {
   TableCell,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { ChevronUp, ChevronDown, Star } from "lucide-react";
+import { ChevronUp, ChevronDown, Star, Crown, Crosshair } from "lucide-react";
 
 type SortKey = keyof Pick<
   PlayerStats,
@@ -52,6 +52,13 @@ function ratingColor(val: number): string {
   if (val > 1.0) return "text-green-400";
   if (val >= 0.8) return "text-yellow-400";
   return "text-red-400";
+}
+
+function ratingTier(val: number): { label: string; color: string } | null {
+  if (val > 1.3) return { label: "Dominant", color: "text-green-400" };
+  if (val >= 1.1) return { label: "Star", color: "text-blue-400" };
+  if (val >= 0.9) return { label: "Solid", color: "text-muted-foreground" };
+  return { label: "Struggling", color: "text-red-400" };
 }
 
 function cellColor(key: SortKey, val: number): string | undefined {
@@ -102,6 +109,41 @@ export function Scoreboard({
     return [...players].sort((a, b) => b.rating - a.rating)[0]?.steamId ?? null;
   }, [players]);
 
+  // compute standout performers per team
+  const standouts = useMemo(() => {
+    const byTeam = (team: string) => players.filter((p) => p.team === team);
+    const computeTeamStandouts = (teamPlayers: PlayerStats[]) => {
+      if (teamPlayers.length === 0) return [];
+      const result: { player: PlayerStats; label: string; stat: string; icon: "mvp" | "entry" }[] = [];
+      const topRating = [...teamPlayers].sort((a, b) => b.rating - a.rating)[0];
+      if (topRating) {
+        const isMvp = topRating.steamId === mvpSteamId;
+        result.push({
+          player: topRating,
+          label: isMvp ? "MVP" : "Top Rated",
+          stat: `${topRating.rating.toFixed(2)} rating`,
+          icon: "mvp",
+        });
+      }
+      // highest K/D player (different from top rating)
+      const topKD = [...teamPlayers].sort((a, b) => (b.kills - b.deaths) - (a.kills - a.deaths))[0];
+      if (topKD && topKD.steamId !== topRating?.steamId) {
+        const diff = topKD.kills - topKD.deaths;
+        result.push({
+          player: topKD,
+          label: "Top Fragger",
+          stat: `${diff > 0 ? "+" : ""}${diff} K/D`,
+          icon: "entry",
+        });
+      }
+      return result;
+    };
+    return {
+      ct: computeTeamStandouts(byTeam("CT")),
+      t: computeTeamStandouts(byTeam("T")),
+    };
+  }, [players, mvpSteamId]);
+
   const computeAverages = (team: PlayerStats[]) => {
     if (team.length === 0) return null;
     const n = team.length;
@@ -119,6 +161,7 @@ export function Scoreboard({
     score: number,
     borderColor: string,
     textColor: string,
+    teamStandouts: { player: PlayerStats; label: string; stat: string; icon: "mvp" | "entry" }[],
   ) => {
     const avg = computeAverages(team);
     return (
@@ -129,6 +172,29 @@ export function Scoreboard({
             <span className={`text-2xl font-bold tabular-nums ${textColor}`}>{score}</span>
           </div>
         </CardHeader>
+        {teamStandouts.length > 0 && (
+          <div className="flex flex-wrap gap-2 px-4 pb-2 pt-1">
+            {teamStandouts.map((s) => (
+              <div
+                key={s.player.steamId}
+                className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-1.5"
+              >
+                {s.icon === "mvp" ? (
+                  <Crown className="h-3.5 w-3.5 text-yellow-400" />
+                ) : (
+                  <Crosshair className="h-3.5 w-3.5 text-blue-400" />
+                )}
+                <div className="text-xs">
+                  <span className="font-medium text-foreground">{s.player.name}</span>
+                  <span className="ml-1.5 text-muted-foreground">{s.stat}</span>
+                </div>
+                <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+                  {s.label}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        )}
         <CardContent className="overflow-x-auto p-0">
           <Table>
             <TableHeader>
@@ -173,14 +239,22 @@ export function Scoreboard({
                         </Badge>
                       )}
                     </TableCell>
-                    {columns.map((col) => (
-                      <TableCell
-                        key={col.key}
-                        className={`text-right tabular-nums ${cellColor(col.key, p[col.key]) ?? ""}`}
-                      >
-                        {col.fmt ? col.fmt(p[col.key]) : p[col.key]}
-                      </TableCell>
-                    ))}
+                    {columns.map((col) => {
+                      const tier = col.key === "rating" ? ratingTier(p[col.key]) : null;
+                      return (
+                        <TableCell
+                          key={col.key}
+                          className={`text-right tabular-nums ${cellColor(col.key, p[col.key]) ?? ""}`}
+                        >
+                          {col.fmt ? col.fmt(p[col.key]) : p[col.key]}
+                          {tier && (
+                            <span className={`ml-1 text-[10px] ${tier.color} opacity-70`}>
+                              {tier.label}
+                            </span>
+                          )}
+                        </TableCell>
+                      );
+                    })}
                     <TableCell className={`text-right tabular-nums ${kdColor(kd)}`}>
                       {kd > 0 ? `+${kd}` : kd}
                     </TableCell>
@@ -220,8 +294,8 @@ export function Scoreboard({
 
   return (
     <div className="space-y-4">
-      {renderTeam(teamA, teamAName, teamAScore, "border-team-ct", "text-team-ct")}
-      {renderTeam(teamB, teamBName, teamBScore, "border-team-t", "text-team-t")}
+      {renderTeam(teamA, teamAName, teamAScore, "border-team-ct", "text-team-ct", standouts.ct)}
+      {renderTeam(teamB, teamBName, teamBScore, "border-team-t", "text-team-t", standouts.t)}
     </div>
   );
 }

--- a/frontend/src/pages/MatchList.tsx
+++ b/frontend/src/pages/MatchList.tsx
@@ -354,6 +354,24 @@ export function MatchList() {
                         <span className={`text-team-t ${bWon ? "font-bold" : ""}`}>
                           {m.teamBScore}
                         </span>
+                        {(() => {
+                          const total = m.teamAScore + m.teamBScore;
+                          const diff = Math.abs(m.teamAScore - m.teamBScore);
+                          const tags: { label: string; cls: string }[] = [];
+                          if (total > 30) tags.push({ label: "OT", cls: "bg-purple-500/20 text-purple-400 border-purple-500/30" });
+                          if (m.teamAScore === 0 || m.teamBScore === 0) tags.push({ label: `${Math.max(m.teamAScore, m.teamBScore)}-0`, cls: "bg-red-500/20 text-red-400 border-red-500/30" });
+                          else if (diff <= 3 && diff > 0) tags.push({ label: "Close", cls: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30" });
+                          if (tags.length === 0) return null;
+                          return (
+                            <span className="ml-1.5 inline-flex gap-1">
+                              {tags.map((t) => (
+                                <Badge key={t.label} variant="outline" className={`px-1 py-0 text-[9px] ${t.cls}`}>
+                                  {t.label}
+                                </Badge>
+                              ))}
+                            </span>
+                          );
+                        })()}
                       </Link>
                     </TableCell>
                     <TableCell className="text-right">


### PR DESCRIPTION
Closes #22

Spec: .manager/specs/017-cs2stats-frontend-vision.md

## Changes
- **Match header**: Result badges (Decisive Win/Close Match/OT), halftime score, longest streak, total rounds
- **Scoreboard**: MVP/Top Fragger callout cards per team, rating performance tier labels (Dominant/Star/Solid/Struggling)
- **Round timeline**: Recharts momentum graph showing score differential with halftime marker, streak badges for 4+ round runs, halftime score label, side-swap-aware team mapping using `teamAStartedAs`
- **Economy**: Buy outcome badges per round (Won/Lost/Eco Win!/Force Win!), economic narrative badges
- **Kill map**: Player highlight dimming — selected player at full opacity, others dimmed
- **Match list**: OT/16-0/Close tags on each match row
- **Types**: Added `teamAStartedAs` to Match interface

7 files changed, 511 insertions, 48 deletions.